### PR TITLE
Update the conversion commands to maintain cover

### DIFF
--- a/src/ControlledAccordions.js
+++ b/src/ControlledAccordions.js
@@ -61,9 +61,9 @@ class ControlledAccordions extends React.Component {
         // " works on ps and cmd as discriminator
 
         const outputFormatCodecMaps = [
-            { format: "m4b", codec: "copy" },
-            { format: "flac", codec: "flac" },
-            { format: "mp3", codec: "libmp3lame" },
+            { format: "m4b", codec: "-codec copy" },
+            { format: "flac", codec: "-codec:a flac" },
+            { format: "mp3", codec: "-codec:a libmp3lame" },
         ];
 
         const osToBinMaps = [
@@ -82,12 +82,13 @@ class ControlledAccordions extends React.Component {
         const di = osMap.discriminator;
         const sep = osMap.separator;
         
-        return `${bin} -y`
-            + ` -activation_bytes ${activationBytes} -i  ${di}.${sep}${fileName}${di}`
-            + ` -map_metadata 0`
-            + ` -id3v2_version 3`
-            + ` -codec:a ${codec}`
-            + ` -vn ${di}${fileNameWithoutExtension}.${outputFormat}${di}`;
+        return [
+            `${bin} -y`,
+            `-activation_bytes ${activationBytes}`,
+            `-i  ${di}.${sep}${fileName}${di}`,
+            codec,
+            `${di}${fileNameWithoutExtension}.${outputFormat}${di}`
+        ].join(" ")
     }
 
     render() {

--- a/src/OnlineConverter.jsx
+++ b/src/OnlineConverter.jsx
@@ -15,17 +15,17 @@ const downloadFile= (data, outputFileName, outputFormat) => {
 }
 const getCommandAsList = (file, outputFileName, outputFormat, activationBytes) =>{
     const outputFormatCodecMaps = [
-        { format: "m4b", codec: "copy" },
-        { format: "flac", codec: "flac" },
-        { format: "mp3", codec: "libmp3lame" },
+        { format: "m4b", codec: "-c copy" },
+        { format: "flac", codec: "-c:a flac" },
+        { format: "mp3", codec: "-c:a libmp3lame" },
     ];
     const codec = outputFormatCodecMaps.filter(x => x.format === outputFormat)[0].codec;
     const filename = file.name;
     return [`-y`,
         '-activation_bytes', activationBytes,
         '-i', filename,
-        '-c:a', codec,
-        '-vn', outputFileName
+        codec,
+        outputFileName
     ];
 }
 const doTranscode = async (file, outputFileName, outputFormat, activationBytes, setMessage) => {


### PR DESCRIPTION
Closes #6 

I updated the conversion commands (both the built in ffmpeg.wasm version as well as the command line string) to remove the `-vn` flag and switch from `-codec:a copy` to `-codec copy` in the case of M4B conversion.

I also removed the metadata mapping flags from the copy/paste version of the command as they are not included in the WASM version and I can't see any benefit they're providing. However, if there is something I'm missing feel free to correct me.

I have tested all the commands locally and they work great but I cannot for the life of me get ffmpeg.wasm working in development mode, even after freshly forking the repo.  It should still work the same but you should probably test it yourself to make sure.