### PR TITLE
Update start command to support node 17+ and add another way to run…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+*~
 
 npm-debug.log*
 yarn-debug.log*

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 The page will reload if you make edits.<br />
 You will also see any lint errors in the console.
 
+If you receive `ERR_CONNECTION_REFUSED` in the console, see the [serve command](#npm-run-serve)
+
+### `npm run serve`
+
+This is an alternative way to run the server locally if you were previously getting `ERR_CONNECTION_REFUSED` in the console. Before running this command, install `serve` with `npm install serve`.
+
 ### `npm run build`
 
 Builds the app for production to the `build` folder.<br />

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "scripts": {
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
-    "start": "react-scripts --openssl-legacy-provider start",
+    "start": "react-scripts --openssl-legacy-provider start || react-scripts start --openssl-legacy-provider",
+    "serve": "serve -s build",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
…the server locally through serve.

With node v19.3.0 I was unable to successfully run the project with `npm run start`, even with the updated node 17+ `start` command. I received `ERR_CONNECTION_REFUSED` after uploading an `.aax`. 

The only way I was able to get this to work was to use the `npm run serve` command which is detailed in `README.md`.